### PR TITLE
Add top 20 Google font pairings

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-@import url("https://fonts.googleapis.com/css2?family=Bitter:ital,wght@0,100..900;1,100..900&family=Fira+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Lora:ital,wght@0,400..700;1,400..700&family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Oswald:wght@200..700&family=PT+Sans:ital,wght@0,400;0,700;1,400;1,700&family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Raleway:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Tinos:ital,wght@0,400;0,700;1,400;1,700&family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100..900;1,100..900&family=Bitter:ital,wght@0,100..900;1,100..900&family=Cabin:ital,wght@0,400..700;1,400..700&family=DM+Serif+Display:ital@0;1&family=Domine:wght@400..700&family=Fira+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Josefin+Sans:ital,wght@0,100..700;1,100..700&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=Lora:ital,wght@0,400..700;1,400..700&family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=Merriweather+Sans:ital,wght@0,300..800;1,300..800&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Mulish:ital,wght@0,200..1000;1,200..1000&family=Nunito:ital,wght@0,200..1000;1,200..1000&family=Open+Sans:ital,wght@0,300..800;1,300..800&family=Oswald:wght@200..700&family=PT+Sans:ital,wght@0,400;0,700;1,400;1,700&family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Raleway:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Roboto+Slab:wght@100..900&family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&family=Source+Sans+Pro:ital,wght@0,200..900;1,200..900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&family=Tinos:ital,wght@0,400;0,700;1,400;1,700&family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap");
 
 .pt-serif-regular {
   font-family: "PT Serif", serif;
@@ -614,3 +614,126 @@
   font-weight: 800;
   font-style: normal;
 }
+
+.source-sans-300 {
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 300;
+  font-style: normal;
+}
+
+.source-sans-400 {
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.source-sans-600 {
+  font-family: "Source Sans Pro", sans-serif;
+  font-weight: 600;
+  font-style: normal;
+}
+
+.source-serif-4-400 {
+  font-family: "Source Serif 4", serif;
+  font-optical-sizing: auto;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.source-serif-4-700 {
+  font-family: "Source Serif 4", serif;
+  font-optical-sizing: auto;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.roboto-slab-400 {
+  font-family: "Roboto Slab", serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.roboto-slab-700 {
+  font-family: "Roboto Slab", serif;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.domine-400 {
+  font-family: "Domine", serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.domine-700 {
+  font-family: "Domine", serif;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.mulish-400 {
+  font-family: "Mulish", sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.mulish-600 {
+  font-family: "Mulish", sans-serif;
+  font-weight: 600;
+  font-style: normal;
+}
+
+.inter-700 {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.nunito-700 {
+  font-family: "Nunito", sans-serif;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.work-sans-700 {
+  font-family: "Work Sans", sans-serif;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.dm-serif-display-regular {
+  font-family: "DM Serif Display", serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+.libre-baskerville-700 {
+  font-family: "Libre Baskerville", serif;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.cabin-700 {
+  font-family: "Cabin", sans-serif;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.merriweather-sans-700 {
+  font-family: "Merriweather Sans", sans-serif;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.josefin-sans-700 {
+  font-family: "Josefin Sans", sans-serif;
+  font-weight: 700;
+  font-style: normal;
+}
+
+.barlow-800 {
+  font-family: "Barlow", sans-serif;
+  font-weight: 800;
+  font-style: normal;
+}
+

--- a/app/page.js
+++ b/app/page.js
@@ -1,97 +1,191 @@
-import Image from "next/image";
+const fontPairs = [
+  {
+    h: {
+      name: "Montserrat",
+      klass: "montserrat-800",
+    },
+    p: { name: "Roboto", klass: "roboto-regular" },
+  },
+  {
+    h: {
+      name: "Playfair Display",
+      klass: "playfair-display-800",
+    },
+    p: { name: "Open Sans", klass: "open-sans-400" },
+  },
+  {
+    h: {
+      name: "Lora",
+      klass: "lora-700",
+    },
+    p: { name: "Lato", klass: "lato-regular" },
+  },
+  {
+    h: {
+      name: "Poppins",
+      klass: "poppins-extrabold",
+    },
+    p: { name: "Source Sans Pro", klass: "source-sans-400" },
+  },
+  {
+    h: {
+      name: "Oswald",
+      klass: "oswald-800",
+    },
+    p: { name: "Merriweather", klass: "merriweather-regular" },
+  },
+  {
+    h: {
+      name: "Raleway",
+      klass: "raleway-800",
+    },
+    p: { name: "Roboto Slab", klass: "roboto-slab-400" },
+  },
+  {
+    h: {
+      name: "Fira Sans",
+      klass: "fira-sans-extrabold",
+    },
+    p: { name: "Source Serif 4", klass: "source-serif-4-400" },
+  },
+  {
+    h: {
+      name: "Ubuntu",
+      klass: "ubuntu-bold",
+    },
+    p: { name: "Open Sans", klass: "open-sans-400" },
+  },
+  {
+    h: {
+      name: "Bitter",
+      klass: "bitter-800",
+    },
+    p: { name: "Source Sans Pro", klass: "source-sans-400" },
+  },
+  {
+    h: {
+      name: "PT Sans",
+      klass: "pt-sans-bold",
+    },
+    p: { name: "PT Serif", klass: "pt-serif-regular" },
+  },
+  {
+    h: {
+      name: "Inter",
+      klass: "inter-700",
+    },
+    p: { name: "Merriweather", klass: "merriweather-regular" },
+  },
+  {
+    h: {
+      name: "Nunito",
+      klass: "nunito-700",
+    },
+    p: { name: "Roboto", klass: "roboto-regular" },
+  },
+  {
+    h: {
+      name: "Work Sans",
+      klass: "work-sans-700",
+    },
+    p: { name: "Domine", klass: "domine-400" },
+  },
+  {
+    h: {
+      name: "DM Serif Display",
+      klass: "dm-serif-display-regular",
+    },
+    p: { name: "Mulish", klass: "mulish-400" },
+  },
+  {
+    h: {
+      name: "Libre Baskerville",
+      klass: "libre-baskerville-700",
+    },
+    p: { name: "Lato", klass: "lato-regular" },
+  },
+  {
+    h: {
+      name: "Cabin",
+      klass: "cabin-700",
+    },
+    p: { name: "Open Sans", klass: "open-sans-400" },
+  },
+  {
+    h: {
+      name: "Source Serif 4",
+      klass: "source-serif-4-700",
+    },
+    p: { name: "Source Sans Pro", klass: "source-sans-400" },
+  },
+  {
+    h: {
+      name: "Merriweather Sans",
+      klass: "merriweather-sans-700",
+    },
+    p: { name: "Merriweather", klass: "merriweather-regular" },
+  },
+  {
+    h: {
+      name: "Josefin Sans",
+      klass: "josefin-sans-700",
+    },
+    p: { name: "PT Serif", klass: "pt-serif-regular" },
+  },
+  {
+    h: {
+      name: "Barlow",
+      klass: "barlow-800",
+    },
+    p: { name: "Roboto", klass: "roboto-regular" },
+  },
+];
 
 export default function Home() {
-  const fonts = [
-    {
-      h: {
-        name: "Montserrat",
-        klass: "montserrat-800",
-      },
-      p: { name: "Roboto", klass: "roboto-regular" },
-    },
-    {
-      h: {
-        name: "Playfair Display",
-        klass: "playfair-display-800",
-      },
-      p: { name: "Open Sans", klass: "open-sans-400" },
-    },
-    {
-      h: {
-        name: "Lora",
-        klass: "lora-700",
-      },
-      p: { name: "Lato", klass: "lato-regular" },
-    },
-    {
-      h: {
-        name: "Poppins",
-        klass: "poppins-extrabold",
-      },
-      p: { name: "Source Sans Pro", klass: "source-sans-400" },
-    },
-    {
-      h: {
-        name: "Oswald",
-        klass: "oswald-800",
-      },
-      p: { name: "Merriweather", klass: "merriweather-regular" },
-    },
-    {
-      h: {
-        name: "Raleway",
-        klass: "raleway-800",
-      },
-      p: { name: "Roboto", klass: "roboto-regular" },
-    },
-    {
-      h: {
-        name: "Fira Sans",
-        klass: "fira-sans-extrabold",
-      },
-      p: { name: "Georgia -> Tinos", klass: "tinos-regular" },
-    },
-    {
-      h: {
-        name: "Ubuntu",
-        klass: "ubuntu-bold",
-      },
-      p: { name: "Open Sans", klass: "open-sans-400" },
-    },
-    {
-      h: {
-        name: "Bitter",
-        klass: "bitter-800",
-      },
-      p: { name: "Source Sans Pro", klass: "source-sans-400" },
-    },
-    {
-      h: {
-        name: "PT Sans",
-        klass: "pt-sans-bold",
-      },
-      p: { name: "PT SERIF", klass: "pt-serif-regular" },
-    },
-  ];
   return (
-    <div className="flex-col max-w-screen-sm mx-auto">
-      {fonts.map((font, index) => (
-        <div
-          className="py-12 px-12 mt-96 min-h-[500px] bg-neutral-50"
-          key={index}
-        >
-          <h1 className={`${font.h.klass} text-6xl pb-8 leading-tight`}>
-            {font.h.name}
-          </h1>
-          <p className={`${font.p.klass} text-md`}>
-            <span className="underline underline-offset-2">{font.p.name}</span>{" "}
-            is Lorem ipsum dolor sit amet consectetur adipisicing elit. Optio,
-            et necessitatibus eaque alias sunt enim voluptas a quasi, itaque
-            possimus ratione consectetur? Praesentium, blanditiis possimus
-            minima similique cupiditate incidunt commodi!
-          </p>
-        </div>
-      ))}
-    </div>
+    <main className="mx-auto flex max-w-4xl flex-col gap-16 px-6 py-16">
+      <header className="space-y-4">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-neutral-500">
+          Top 20 Pairings
+        </p>
+        <h1 className="text-4xl font-semibold text-neutral-900 sm:text-5xl">
+          Heading & paragraph fonts that work beautifully together
+        </h1>
+        <p className="text-base text-neutral-600 sm:text-lg">
+          Explore proven Google Font combinations for hero sections, editorials,
+          product pages and long-form reading. Each pairing balances a confident
+          display face with a reliable text companion.
+        </p>
+      </header>
+      <section className="flex flex-col gap-12">
+        {fontPairs.map((font, index) => (
+          <article
+            className="rounded-3xl border border-neutral-200 bg-neutral-50 p-10 shadow-sm"
+            key={`${font.h.name}-${font.p.name}`}
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">
+              Pair {String(index + 1).padStart(2, "0")}
+            </p>
+            <h2
+              className={`${font.h.klass} mt-4 text-4xl leading-tight text-neutral-900 sm:text-5xl`}
+            >
+              {font.h.name}
+            </h2>
+            <p className="mt-2 text-sm uppercase tracking-wide text-neutral-500">
+              Heading font
+            </p>
+            <p
+              className={`${font.p.klass} mt-6 text-base leading-relaxed text-neutral-700 sm:text-lg`}
+            >
+              This duo balances <span className="font-semibold text-neutral-900">{font.h.name}</span>
+              {" "}headlines with <span className="font-semibold text-neutral-900">{font.p.name}</span>
+              {" "}body copy so longer reads stay clear and inviting. Use it for
+              marketing pages, editorial layouts, and product experiences that
+              need polish and readability.
+            </p>
+          </article>
+        ))}
+      </section>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- replace the home page layout with an introductory section and cards for 20 curated heading/paragraph font pairings
- expand the data set with additional Google fonts and styles so each card demonstrates a high quality pairing
- import the new font families and add utility classes for Source Sans Pro, Source Serif 4, Roboto Slab, and other pair members

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd30e867ec832089245075492d2566